### PR TITLE
Define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H

### DIFF
--- a/proj/proj.h
+++ b/proj/proj.h
@@ -1,3 +1,4 @@
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H yes
 #include <proj_api.h>
 
 char *transform(projPJ srcdefn, projPJ dstdefn, long point_count, double *x, double *y, double *z);


### PR DESCRIPTION
This is to avoid the following error:

/usr/include/proj_api.h:37:2: error: #error 'To use the proj_api.h you
must define the macro ACCEPT_USE_OF_DEPRECATED_PROJ_API_H'

This is necessary when using proj version 6.0.0 onwards. See release notes [here](https://github.com/OSGeo/PROJ/releases/tag/6.0.0).